### PR TITLE
update 'Collection.toArray()' call style to improve performance in JDK6+

### DIFF
--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/TxCommands.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/TxCommands.java
@@ -34,6 +34,7 @@ import org.apache.ignite.internal.client.GridClientException;
 import org.apache.ignite.internal.commandline.argument.CommandArgUtils;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
 import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.internal.visor.tx.FetchNearXidVersionTask;
 import org.apache.ignite.internal.visor.tx.TxKeyLockType;
 import org.apache.ignite.internal.visor.tx.TxMappingType;
@@ -95,7 +96,7 @@ public class TxCommands extends AbstractCommand<VisorTxTaskArg> {
         list.add(optional(TX_INFO));
         list.add(optional(CMD_AUTO_CONFIRMATION));
 
-        return list.toArray(new String[list.size()]);
+        return list.toArray(U.EMPTY_STRS);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/cache/store/jdbc/dialect/BasicJdbcDialect.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/store/jdbc/dialect/BasicJdbcDialect.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import org.apache.ignite.internal.util.typedef.C1;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.SB;
+import org.apache.ignite.internal.util.typedef.internal.U;
 
 /**
  * Basic implementation of dialect based on JDBC specification.
@@ -175,7 +176,7 @@ public class BasicJdbcDialect implements JdbcDialect {
 
         SB sb = new SB();
 
-        String[] cols = keyCols.toArray(new String[keyCols.size()]);
+        String[] cols = keyCols.toArray(U.EMPTY_STRS);
 
         if (appendLowerBound) {
             sb.a("(");

--- a/modules/core/src/main/java/org/apache/ignite/configuration/TransactionConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/TransactionConfiguration.java
@@ -23,6 +23,7 @@ import javax.cache.configuration.Factory;
 import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.internal.util.TransientSerializable;
 import org.apache.ignite.internal.util.typedef.internal.S;
+import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteExperimental;
 import org.apache.ignite.lang.IgniteProductVersion;
 import org.apache.ignite.transactions.Transaction;
@@ -477,6 +478,6 @@ public class TransactionConfiguration implements Serializable {
         if (DEADLOCK_TIMEOUT_SINCE.compareToIgnoreTimestamp(ver) >= 0)
             transients.add("deadlockTimeout");
 
-        return transients.isEmpty() ? null : transients.toArray(new String[transients.size()]);
+        return transients.isEmpty() ? null : transients.toArray(U.EMPTY_STRS);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
@@ -2010,7 +2010,7 @@ public class IgnitionEx {
                 }
             }
 
-            cfg.setCacheConfiguration(cacheCfgs.toArray(new CacheConfiguration[cacheCfgs.size()]));
+            cfg.setCacheConfiguration(cacheCfgs.toArray(new CacheConfiguration[0]));
 
             assert cfg.getCacheConfiguration() != null;
         }
@@ -2067,7 +2067,7 @@ public class IgnitionEx {
                 if (!dfltLoadBalancingSpi)
                     spis.add(new RoundRobinLoadBalancingSpi());
 
-                cfg.setLoadBalancingSpi(spis.toArray(new LoadBalancingSpi[spis.size()]));
+                cfg.setLoadBalancingSpi(spis.toArray(new LoadBalancingSpi[0]));
             }
 
             if (cfg.getIndexingSpi() == null)
@@ -2682,8 +2682,7 @@ public class IgnitionEx {
         }
 
         if (!optionalDataRegions.isEmpty())
-            dsCfg.setDataRegionConfigurations(optionalDataRegions.toArray(
-                new DataRegionConfiguration[optionalDataRegions.size()]));
+            dsCfg.setDataRegionConfigurations(optionalDataRegions.toArray(new DataRegionConfiguration[0]));
 
         if (!customDfltPlc) {
             if (!DFLT_MEM_PLC_DEFAULT_NAME.equals(memCfg.getDefaultMemoryPolicyName())) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryClassDescriptor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryClassDescriptor.java
@@ -377,7 +377,7 @@ public class BinaryClassDescriptor {
                         }
                     }
 
-                    fields = fields0.values().toArray(new BinaryFieldAccessor[fields0.size()]);
+                    fields = fields0.values().toArray(new BinaryFieldAccessor[0]);
 
                     BinarySchema.Builder schemaBuilder = BinarySchema.Builder.newBuilder();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/JdbcThinPreparedStatement.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/JdbcThinPreparedStatement.java
@@ -274,10 +274,10 @@ public class JdbcThinPreparedStatement extends JdbcThinStatement implements Prep
             if (batch == null) {
                 batch = new ArrayList<>();
 
-                batch.add(new JdbcQuery(sql, args.toArray(new Object[args.size()])));
+                batch.add(new JdbcQuery(sql, args.toArray(new Object[0])));
             }
             else
-                batch.add(new JdbcQuery(null, args.toArray(new Object[args.size()])));
+                batch.add(new JdbcQuery(null, args.toArray(new Object[0])));
         }
 
         args = null;

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/JdbcThinStatement.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/JdbcThinStatement.java
@@ -229,7 +229,7 @@ public class JdbcThinStatement implements Statement {
         }
 
         JdbcQueryExecuteRequest req = new JdbcQueryExecuteRequest(stmtType, schema, pageSize,
-            maxRows, conn.getAutoCommit(), explicitTimeout, sql, args == null ? null : args.toArray(new Object[args.size()]));
+            maxRows, conn.getAutoCommit(), explicitTimeout, sql, args == null ? null : args.toArray(new Object[0]));
 
         JdbcResultWithIo resWithIo = conn.sendRequest(req, this, null);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/GridIoManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/GridIoManager.java
@@ -478,7 +478,7 @@ public class GridIoManager extends GridManagerAdapter<CommunicationSpi<Serializa
         }
 
         if (!compMsgs.isEmpty())
-            msgs = F.concat(msgs, compMsgs.toArray(new MessageFactory[compMsgs.size()]));
+            msgs = F.concat(msgs, compMsgs.toArray(new MessageFactory[0]));
 
         msgFactory = new IgniteMessageFactoryImpl(msgs);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtCacheEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtCacheEntry.java
@@ -759,7 +759,7 @@ public class GridDhtCacheEntry extends GridDistributedCacheEntry {
         }
 
         if (newRdrs != null) {
-            rdrs = newRdrs.toArray(new ReaderId[newRdrs.size()]);
+            rdrs = newRdrs.toArray(ReaderId.EMPTY_ARRAY);
 
             this.rdrs = rdrs;
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/dotnet/PlatformDotNetConfigurationClosure.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/dotnet/PlatformDotNetConfigurationClosure.java
@@ -210,7 +210,7 @@ public class PlatformDotNetConfigurationClosure extends PlatformAbstractConfigur
         }
 
         if (!newBeans.isEmpty()) {
-            LifecycleBean[] newBeans0 = newBeans.toArray(new LifecycleBean[newBeans.size()]);
+            LifecycleBean[] newBeans0 = newBeans.toArray(new LifecycleBean[0]);
 
             // New beans were added. Let's append them to the tail of the rest configured lifecycle beans.
             LifecycleBean[] oldBeans = cfg.getLifecycleBeans();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/utils/PlatformConfigurationUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/utils/PlatformConfigurationUtils.java
@@ -289,7 +289,7 @@ public class PlatformConfigurationUtils {
             if (ccfg.getPluginConfigurations() != null)
                 Collections.addAll(plugins, ccfg.getPluginConfigurations());
 
-            ccfg.setPluginConfigurations(plugins.toArray(new CachePluginConfiguration[plugins.size()]));
+            ccfg.setPluginConfigurations(plugins.toArray(new CachePluginConfiguration[0]));
         }
 
         return ccfg;
@@ -979,7 +979,7 @@ public class PlatformConfigurationUtils {
             caches.add(readCacheConfiguration(in));
 
         CacheConfiguration[] oldCaches = cfg.getCacheConfiguration();
-        CacheConfiguration[] caches0 = caches.toArray(new CacheConfiguration[caches.size()]);
+        CacheConfiguration[] caches0 = caches.toArray(new CacheConfiguration[0]);
 
         if (oldCaches == null)
             cfg.setCacheConfiguration(caches0);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/utils/PlatformUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/utils/PlatformUtils.java
@@ -481,7 +481,7 @@ public class PlatformUtils {
                     res0.add(CachePeekMode.fromOrdinal((byte)i));
             }
 
-            res = res0.toArray(new CachePeekMode[res0.size()]);
+            res = res0.toArray(new CachePeekMode[0]);
 
             synchronized (PlatformUtils.class) {
                 CACHE_PEEK_MODES[modes] = res;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/resource/GridResourceField.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/resource/GridResourceField.java
@@ -82,7 +82,7 @@ class GridResourceField {
         if (c.isEmpty())
             return EMPTY_ARRAY;
 
-        return c.toArray(new GridResourceField[c.size()]);
+        return c.toArray(EMPTY_ARRAY);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/resource/GridResourceIoc.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/resource/GridResourceIoc.java
@@ -307,7 +307,7 @@ public class GridResourceIoc {
             }
 
             recursiveFields = recursiveFieldsList.isEmpty() ? U.EMPTY_FIELDS
-                : recursiveFieldsList.toArray(new Field[recursiveFieldsList.size()]);
+                : recursiveFieldsList.toArray(U.EMPTY_FIELDS);
 
             this.annMap = IgniteUtils.limitedMap(annMap.size());
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/resource/GridResourceMethod.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/resource/GridResourceMethod.java
@@ -77,7 +77,7 @@ class GridResourceMethod {
         if (c.isEmpty())
             return EMPTY_ARRAY;
 
-        return c.toArray(new GridResourceMethod[c.size()]);
+        return c.toArray(EMPTY_ARRAY);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -635,7 +635,7 @@ public abstract class IgniteUtils {
     private static final boolean assertionsEnabled;
 
     /** Empty URL array. */
-    private static final URL[] EMPTY_URL_ARR = new URL[0];
+    public static final URL[] EMPTY_URL_ARR = new URL[0];
 
     /** Builtin class loader class.
      *

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/io/GridFilenameUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/io/GridFilenameUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.internal.util.io;
 
+import org.apache.ignite.internal.util.typedef.internal.U;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -1337,7 +1339,7 @@ public class GridFilenameUtils {
         if (buffer.length() != 0)
             list.add(buffer.toString());
 
-        return list.toArray( new String[ list.size() ] );
+        return list.toArray(U.EMPTY_STRS);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioRecoveryDescriptor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioRecoveryDescriptor.java
@@ -254,7 +254,7 @@ public class GridNioRecoveryDescriptor {
                 return false;
 
             if (!msgReqs.isEmpty()) {
-                reqs = msgReqs.toArray(new SessionWriteRequest[msgReqs.size()]);
+                reqs = msgReqs.toArray(new SessionWriteRequest[0]);
 
                 msgReqs.clear();
             }
@@ -401,7 +401,7 @@ public class GridNioRecoveryDescriptor {
             }
 
             if (nodeLeft && !msgReqs.isEmpty()) {
-                futs = msgReqs.toArray(new SessionWriteRequest[msgReqs.size()]);
+                futs = msgReqs.toArray(new SessionWriteRequest[0]);
 
                 msgReqs.clear();
             }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/typedef/X.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/typedef/X.java
@@ -826,7 +826,7 @@ public final class X {
     public static Throwable[] getThrowables(Throwable throwable) {
         List<Throwable> list = getThrowableList(throwable);
 
-        return list.toArray(new Throwable[list.size()]);
+        return list.toArray(new Throwable[0]);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/spi/communication/tcp/internal/GridNioServerWrapper.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/communication/tcp/internal/GridNioServerWrapper.java
@@ -911,7 +911,7 @@ public class GridNioServerWrapper {
                     .directMode(true)
                     .writeTimeout(cfg.socketWriteTimeout())
                     .selectorSpins(cfg.selectorSpins())
-                    .filters(filters.toArray(new GridNioFilter[filters.size()]))
+                    .filters(filters.toArray(new GridNioFilter[0]))
                     .writerFactory(writerFactory)
                     .skipRecoveryPredicate(skipRecoveryPred)
                     .messageQueueSizeListener(queueSizeMonitor)

--- a/modules/core/src/main/java/org/apache/ignite/spi/metric/jmx/MetricRegistryMBean.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/metric/jmx/MetricRegistryMBean.java
@@ -115,7 +115,7 @@ public class MetricRegistryMBean extends ReadOnlyDynamicMBean {
         return new MBeanInfo(
             ReadOnlyMetricManager.class.getName(),
             mreg.name(),
-            attributes.toArray(new MBeanAttributeInfo[attributes.size()]),
+            attributes.toArray(new MBeanAttributeInfo[0]),
             null,
             null,
             null);

--- a/modules/core/src/test/java/org/apache/ignite/cache/store/jdbc/CacheJdbcStoreAbstractMultithreadedSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/store/jdbc/CacheJdbcStoreAbstractMultithreadedSelfTest.java
@@ -101,7 +101,7 @@ public abstract class CacheJdbcStoreAbstractMultithreadedSelfTest<T extends Cach
 
             Collection<JdbcType> types = new ArrayList<>(springCtx.getBeansOfType(JdbcType.class).values());
 
-            store.setTypes(types.toArray(new JdbcType[types.size()]));
+            store.setTypes(types.toArray(new JdbcType[0]));
         }
         catch (BeansException e) {
             if (X.hasCause(e, ClassNotFoundException.class))

--- a/modules/core/src/test/java/org/apache/ignite/internal/GridProjectionForCachesSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/GridProjectionForCachesSelfTest.java
@@ -60,7 +60,7 @@ public class GridProjectionForCachesSelfTest extends GridCommonAbstractTest {
             ccfgs.add(cacheConfiguration(CACHE_NAME, new AttributeFilter(getTestIgniteInstanceName(2),
                 getTestIgniteInstanceName(3)), true));
 
-        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         return cfg;
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/SensitiveInfoTestLoggerProxy.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/SensitiveInfoTestLoggerProxy.java
@@ -212,7 +212,7 @@ public class SensitiveInfoTestLoggerProxy implements IgniteLogger, LifecycleAwar
             ex.printStackTrace();
         }
 
-        return lst.toArray(new Pattern[lst.size()]);
+        return lst.toArray(new Pattern[0]);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryEnumsSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryEnumsSelfTest.java
@@ -549,7 +549,7 @@ public class BinaryEnumsSelfTest extends AbstractBinaryArraysTest {
                         EnumType.TWO.name(), EnumType.TWO.ordinal()));
 
         Collection<BinaryObject> vals = node1.binary().type(enumName).enumValues();
-        BinaryObject[] values = vals.toArray(new BinaryObject[vals.size()]);
+        BinaryObject[] values = vals.toArray(new BinaryObject[0]);
 
         assertEquals(2, values.length);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheExchangeMessageDuplicatedStateTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheExchangeMessageDuplicatedStateTest.java
@@ -122,7 +122,7 @@ public class CacheExchangeMessageDuplicatedStateTest extends GridCommonAbstractT
             ccfgs.add(ccfg);
         }
 
-        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         return cfg;
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheWithDifferentDataRegionConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheWithDifferentDataRegionConfigurationTest.java
@@ -400,13 +400,13 @@ public class CacheWithDifferentDataRegionConfigurationTest extends GridCommonAbs
             cfg.setConsistentId(gridName);
 
             DataStorageConfiguration storageCfg = new DataStorageConfiguration();
-            storageCfg.setDataRegionConfigurations(regions.toArray(new DataRegionConfiguration[regions.size()]));
+            storageCfg.setDataRegionConfigurations(regions.toArray(new DataRegionConfiguration[0]));
             cfg.setDataStorageConfiguration(storageCfg);
 
             if (dfltRegionConfiguration != null)
                 storageCfg.setDefaultDataRegionConfiguration(dfltRegionConfiguration);
 
-            cfg.setCacheConfiguration(caches.toArray(new CacheConfiguration[caches.size()]));
+            cfg.setCacheConfiguration(caches.toArray(new CacheConfiguration[0]));
 
             return startGrid(cfg);
         }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCachePartitionMapUpdateTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCachePartitionMapUpdateTest.java
@@ -95,7 +95,7 @@ public class IgniteCachePartitionMapUpdateTest extends GridCommonAbstractTest {
 
         cfg.setUserAttributes(attrs);
 
-        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         return cfg;
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/IgniteSequenceInternalCleanupTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/IgniteSequenceInternalCleanupTest.java
@@ -68,7 +68,7 @@ public class IgniteSequenceInternalCleanupTest extends GridCommonAbstractTest {
                 setAffinity(new RendezvousAffinityFunction(false, 16)));
         }
 
-        cfg.setCacheConfiguration(cacheCfg.toArray(new CacheConfiguration[cacheCfg.size()]));
+        cfg.setCacheConfiguration(cacheCfg.toArray(new CacheConfiguration[0]));
 
         return cfg;
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/GridCacheTransformEventSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/GridCacheTransformEventSelfTest.java
@@ -571,7 +571,7 @@ public class GridCacheTransformEventSelfTest extends GridCommonAbstractTest {
             }
         }
 
-        return res.toArray(new UUID[res.size()]);
+        return res.toArray(new UUID[0]);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/baseline/ClientAffinityAssignmentWithBaselineTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/baseline/ClientAffinityAssignmentWithBaselineTest.java
@@ -149,9 +149,9 @@ public class ClientAffinityAssignmentWithBaselineTest extends GridCommonAbstract
         clientConfigs.add(cacheConfig(PARTITIONED_TX_CLIENT_CACHE_NAME));
 
         if (igniteInstanceName.startsWith(CLIENT_GRID_NAME))
-            cfg.setCacheConfiguration(clientConfigs.toArray(new CacheConfiguration[clientConfigs.size()]));
+            cfg.setCacheConfiguration(clientConfigs.toArray(new CacheConfiguration[0]));
         else
-            cfg.setCacheConfiguration(srvConfigs.toArray(new CacheConfiguration[srvConfigs.size()]));
+            cfg.setCacheConfiguration(srvConfigs.toArray(new CacheConfiguration[0]));
 
         // Enforce different mac adresses to emulate distributed environment by default.
         cfg.setUserAttributes(Collections.singletonMap(

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/checkpoint/IgniteCheckpointDirtyPagesForLowLoadTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/checkpoint/IgniteCheckpointDirtyPagesForLowLoadTest.java
@@ -69,7 +69,7 @@ public class IgniteCheckpointDirtyPagesForLowLoadTest extends GridCommonAbstract
                 ccfgs.add(ccfg);
             }
         }
-        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         DataStorageConfiguration dsCfg = new DataStorageConfiguration();
         dsCfg.setDefaultDataRegionConfiguration(

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/service/GridServiceProcessorMultiNodeConfigSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/service/GridServiceProcessorMultiNodeConfigSelfTest.java
@@ -107,7 +107,7 @@ public class GridServiceProcessorMultiNodeConfigSelfTest extends GridServiceProc
 
         cfgs.add(cfg);
 
-        return cfgs.toArray(new ServiceConfiguration[cfgs.size()]);
+        return cfgs.toArray(new ServiceConfiguration[0]);
     }
 
     /** {@inheritDoc} */

--- a/modules/dev-utils/src/test/java/org/apache/ignite/development/utils/IgniteWalConverterSensitiveDataTest.java
+++ b/modules/dev-utils/src/test/java/org/apache/ignite/development/utils/IgniteWalConverterSensitiveDataTest.java
@@ -46,6 +46,7 @@ import org.apache.ignite.internal.processors.cache.GridCacheOperation;
 import org.apache.ignite.internal.processors.cache.KeyCacheObjectImpl;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
 import org.apache.ignite.internal.util.typedef.internal.CU;
+import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.apache.ignite.transactions.Transaction;
 import org.junit.Test;
@@ -249,7 +250,7 @@ public class IgniteWalConverterSensitiveDataTest extends GridCommonAbstractTest 
         if (processSensitiveData != null)
             args.add("processSensitiveData=" + processSensitiveData.name());
 
-        IgniteWalConverter.main(args.toArray(new String[args.size()]));
+        IgniteWalConverter.main(args.toArray(U.EMPTY_STRS));
 
         String testOutStr = testOut.toString();
 

--- a/modules/extdata/platform/src/test/java/org/apache/ignite/platform/plugin/PlatformTestPluginConfigurationClosureFactory.java
+++ b/modules/extdata/platform/src/test/java/org/apache/ignite/platform/plugin/PlatformTestPluginConfigurationClosureFactory.java
@@ -55,6 +55,6 @@ public class PlatformTestPluginConfigurationClosureFactory implements PlatformPl
 
         cfgs.add(plugCfg);
 
-        cfg.setPluginConfigurations(cfgs.toArray(new PluginConfiguration[cfgs.size()]));
+        cfg.setPluginConfigurations(cfgs.toArray(new PluginConfiguration[0]));
     }
 }

--- a/modules/extdata/platform/src/test/java/org/apache/ignite/platform/plugin/cache/PlatformTestCachePluginConfigurationClosure.java
+++ b/modules/extdata/platform/src/test/java/org/apache/ignite/platform/plugin/cache/PlatformTestCachePluginConfigurationClosure.java
@@ -42,6 +42,6 @@ public class PlatformTestCachePluginConfigurationClosure implements PlatformCach
 
         cfgs.add(plugCfg);
 
-        cacheConfiguration.setPluginConfigurations(cfgs.toArray(new CachePluginConfiguration[cfgs.size()]));
+        cacheConfiguration.setPluginConfigurations(cfgs.toArray(new CachePluginConfiguration[0]));
     }
 }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2IndexFactory.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2IndexFactory.java
@@ -73,7 +73,7 @@ class H2IndexFactory {
                     : org.h2.result.SortOrder.DESCENDING));
         }
 
-        IndexColumn[] idxColsArr = idxCols.toArray(new IndexColumn[idxCols.size()]);
+        IndexColumn[] idxColsArr = idxCols.toArray(H2Utils.EMPTY_COLUMNS);
 
         if (idxDesc.type() == QueryIndexType.SORTED) {
             if (idxDesc.isProxy()) {

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2ProxyIndex.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2ProxyIndex.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import org.apache.ignite.internal.processors.query.GridQueryRowDescriptor;
 import org.apache.ignite.internal.processors.query.QueryUtils;
+import org.apache.ignite.internal.processors.query.h2.H2Utils;
 import org.apache.ignite.internal.processors.query.h2.opt.join.ProxyDistributedLookupBatch;
 import org.h2.engine.Session;
 import org.h2.index.Cursor;
@@ -59,7 +60,7 @@ public class GridH2ProxyIndex extends H2IndexCostedBase {
         super(tbl, name, GridH2IndexBase.columnsArray(tbl, colsList),
             IndexType.createNonUnique(false, false, idx instanceof SpatialIndex));
 
-        IndexColumn[] cols = colsList.toArray(new IndexColumn[colsList.size()]);
+        IndexColumn[] cols = colsList.toArray(H2Utils.EMPTY_COLUMNS);
 
         IndexColumn.mapColumns(cols, tbl);
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteBinaryObjectQueryArgumentsTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteBinaryObjectQueryArgumentsTest.java
@@ -130,7 +130,7 @@ public class IgniteBinaryObjectQueryArgumentsTest extends GridCommonAbstractTest
         ccfgs.addAll(getCacheConfigurations(BIG_DECIMAL_CACHE, BigDecimal.class, Person.class));
         ccfgs.add(getCacheConfiguration(FIELD_CACHE, Integer.class, SearchValue.class));
 
-        return ccfgs.toArray(new CacheConfiguration[ccfgs.size()]);
+        return ccfgs.toArray(new CacheConfiguration[0]);
     }
 
     /**

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinCollocatedAndNotTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinCollocatedAndNotTest.java
@@ -112,7 +112,7 @@ public class IgniteCacheDistributedJoinCollocatedAndNotTest extends GridCommonAb
             ccfgs.add(ccfg);
         }
 
-        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         return cfg;
     }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinCustomAffinityMapper.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinCustomAffinityMapper.java
@@ -119,7 +119,7 @@ public class IgniteCacheDistributedJoinCustomAffinityMapper extends GridCommonAb
             ccfgs.add(ccfg);
         }
 
-        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         return cfg;
     }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinNoIndexTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinNoIndexTest.java
@@ -84,7 +84,7 @@ public class IgniteCacheDistributedJoinNoIndexTest extends GridCommonAbstractTes
             ccfgs.add(ccfg);
         }
 
-        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         return cfg;
     }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheJoinPartitionedAndReplicatedTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheJoinPartitionedAndReplicatedTest.java
@@ -108,7 +108,7 @@ public class IgniteCacheJoinPartitionedAndReplicatedTest extends GridCommonAbstr
             ccfgs.add(ccfg);
         }
 
-        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        cfg.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         return cfg;
     }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/index/DynamicColumnsAbstractConcurrentSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/index/DynamicColumnsAbstractConcurrentSelfTest.java
@@ -1002,7 +1002,7 @@ public abstract class DynamicColumnsAbstractConcurrentSelfTest extends DynamicCo
 
         String idxQry = "CREATE INDEX idx ON " + TBL_NAME + '(';
 
-        Integer[] sorted = fields.toArray(new Integer[fields.size()]);
+        Integer[] sorted = fields.toArray(new Integer[0]);
 
         Arrays.sort(sorted);
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlKeyValueFieldsTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlKeyValueFieldsTest.java
@@ -94,7 +94,7 @@ public class IgniteSqlKeyValueFieldsTest extends AbstractIndexingCommonTest {
         ccfgs.add(buildCacheConfiguration(CACHE_JOB));
         ccfgs.add(buildCacheConfiguration(CACHE_SQL));
 
-        c.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        c.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         return c;
     }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlNotNullConstraintTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlNotNullConstraintTest.java
@@ -118,7 +118,7 @@ public class IgniteSqlNotNullConstraintTest extends AbstractIndexingCommonTest {
         if (gridName.equals(INTERCEPTOR_CFG_NODE_NAME))
             ccfgs.add(buildCacheConfigurationRestricted("BadCfgTestCacheINT", false, true, true));
 
-        c.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        c.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         if (gridName.equals(NODE_CLIENT)) {
             // Not allowed to have local cache on client without memory config

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlRoutingTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlRoutingTest.java
@@ -87,7 +87,7 @@ public class IgniteSqlRoutingTest extends AbstractIndexingCommonTest {
         ccfgs.add(buildCacheConfiguration(CACHE_PERSON));
         ccfgs.add(buildCacheConfiguration(CACHE_CALL));
 
-        c.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        c.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
         c.setCacheKeyConfiguration(new CacheKeyConfiguration(CallKey.class));
         c.setIncludeEventTypes(EventType.EVTS_ALL);
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlSkipReducerOnUpdateDmlFlagSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlSkipReducerOnUpdateDmlFlagSelfTest.java
@@ -75,7 +75,7 @@ public class IgniteSqlSkipReducerOnUpdateDmlFlagSelfTest extends AbstractIndexin
         ccfgs.add(buildCacheConfiguration(CACHE_REPORT));
         ccfgs.add(buildCacheConfiguration(CACHE_LIST));
 
-        c.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        c.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
 
         return c;
     }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlSkipReducerOnUpdateDmlSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlSkipReducerOnUpdateDmlSelfTest.java
@@ -95,7 +95,7 @@ public class IgniteSqlSkipReducerOnUpdateDmlSelfTest extends AbstractIndexingCom
         ccfgs.add(buildCacheConfiguration(CACHE_PERSON));
         ccfgs.add(buildCacheConfiguration(CACHE_POSITION));
 
-        c.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[ccfgs.size()]));
+        c.setCacheConfiguration(ccfgs.toArray(new CacheConfiguration[0]));
         c.setSqlConfiguration(new SqlConfiguration().setLongQueryWarningTimeout(10000));
         c.setIncludeEventTypes(EventType.EVTS_ALL);
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/TableStatisticsAbstractTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/TableStatisticsAbstractTest.java
@@ -23,6 +23,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 
 /**
@@ -61,7 +62,7 @@ public abstract class TableStatisticsAbstractTest extends GridCommonAbstractTest
 
         Collections.reverse(dirOrdTbls);
 
-        String reversedOrder = replaceTablePlaceholders(sql, dirOrdTbls.toArray(new String[dirOrdTbls.size()]));
+        String reversedOrder = replaceTablePlaceholders(sql, dirOrdTbls.toArray(U.EMPTY_STRS));
 
         if (log.isDebugEnabled())
             log.debug("Reversed join order=" + reversedOrder);

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/stat/StatisticsAbstractTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/stat/StatisticsAbstractTest.java
@@ -153,7 +153,7 @@ public abstract class StatisticsAbstractTest extends GridCommonAbstractTest {
 
         Collections.reverse(dirOrdTbls);
 
-        String reversedOrder = replaceTablePlaceholders(sql, dirOrdTbls.toArray(new String[dirOrdTbls.size()]));
+        String reversedOrder = replaceTablePlaceholders(sql, dirOrdTbls.toArray(U.EMPTY_STRS));
 
         if (log.isDebugEnabled())
             log.debug("Reversed join order=" + reversedOrder);
@@ -200,7 +200,7 @@ public abstract class StatisticsAbstractTest extends GridCommonAbstractTest {
         while (m.find())
             result.add(m.group(1).trim());
 
-        return result.toArray(new String[result.size()]);
+        return result.toArray(U.EMPTY_STRS);
     }
 
     /**

--- a/modules/ml/src/main/java/org/apache/ignite/ml/clustering/gmm/GmmTrainer.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/clustering/gmm/GmmTrainer.java
@@ -178,7 +178,7 @@ public class GmmTrainer extends SingleLabelDatasetTrainer<GmmModel> {
     public GmmTrainer withInitialMeans(List<Vector> means) {
         A.notEmpty(means, "GMM should start with non empty initial components list");
 
-        this.initialMeans = means.toArray(new Vector[means.size()]);
+        this.initialMeans = means.toArray(new Vector[0]);
         this.countOfComponents = means.size();
         if (countOfComponents > maxCountOfClusters)
             maxCountOfClusters = countOfComponents;

--- a/modules/tools/src/main/java/org/apache/ignite/tools/junit/X.java
+++ b/modules/tools/src/main/java/org/apache/ignite/tools/junit/X.java
@@ -306,7 +306,7 @@ final class X {
     private static Throwable[] getThrowables(Throwable throwable) {
         List<Throwable> list = getThrowableList(throwable);
 
-        return list.toArray(new Throwable[list.size()]);
+        return list.toArray(new Throwable[0]);
     }
 
     /**

--- a/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentClassLoaderFactory.java
+++ b/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentClassLoaderFactory.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.spi.IgniteSpiException;
 
 /**
@@ -79,7 +80,7 @@ class GridUriDeploymentClassLoaderFactory {
                 }
             }
 
-            return new GridUriDeploymentClassLoader(urls.toArray(new URL[urls.size()]), parent);
+            return new GridUriDeploymentClassLoader(urls.toArray(U.EMPTY_URL_ARR), parent);
         }
         catch (MalformedURLException e) {
             throw new IgniteSpiException("Failed to create class loader for a package: " + file, e);

--- a/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentJarVerifier.java
+++ b/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentJarVerifier.java
@@ -391,7 +391,7 @@ final class GridUriDeploymentJarVerifier {
                 certChains.addAll(signer.getSignerCertPath().getCertificates());
 
             // Convert into a Certificate[]
-            return certChains.toArray(new Certificate[certChains.size()]);
+            return certChains.toArray(new Certificate[0]);
         }
 
         return certs;

--- a/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/UriDeploymentSpi.java
+++ b/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/UriDeploymentSpi.java
@@ -1124,7 +1124,7 @@ public class UriDeploymentSpi extends IgniteSpiAdapter implements DeploymentSpi 
 
         if (clss != null && !clss.isEmpty()) {
             try {
-                addResources(newDesc.getClassLoader(), newDesc, clss.toArray(new Class<?>[clss.size()]));
+                addResources(newDesc.getClassLoader(), newDesc, clss.toArray(new Class<?>[0]));
             }
             catch (IgniteSpiException e) {
                 U.warn(log, "Failed to register a class loader for a package [newDesc=" + newDesc +

--- a/modules/web/src/main/java/org/apache/ignite/cache/websession/WebSession.java
+++ b/modules/web/src/main/java/org/apache/ignite/cache/websession/WebSession.java
@@ -266,7 +266,7 @@ class WebSession implements HttpSession, Externalizable {
         if (!isValid)
             throw new IllegalStateException("Call on invalidated session!");
 
-        return attrs.keySet().toArray(new String[attrs.size()]);
+        return attrs.keySet().toArray(U.EMPTY_STRS);
     }
 
     /** {@inheritDoc} */

--- a/modules/web/src/main/java/org/apache/ignite/cache/websession/WebSessionV2.java
+++ b/modules/web/src/main/java/org/apache/ignite/cache/websession/WebSessionV2.java
@@ -268,7 +268,7 @@ class WebSessionV2 implements HttpSession {
 
         final Set<String> names = attributeNames();
 
-        return names.toArray(new String[names.size()]);
+        return names.toArray(U.EMPTY_STRS);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
The toArray(new T[0]) variant is faster than the toArray(new T[size]) and, therefore, should always be the preferred option when we have to convert a collection to an array.